### PR TITLE
Update 5_promoter_biophysical_gpmaps.ipynb

### DIFF
--- a/docs/tutorials/5_promoter_biophysical_gpmaps.ipynb
+++ b/docs/tutorials/5_promoter_biophysical_gpmaps.ipynb
@@ -642,6 +642,7 @@
     "$$\n",
     "tr_{\\text{rate}} = t_{sat} \\frac {\\exp(-\\Delta G_R)+ \\exp(-\\Delta G_C-\\Delta G_R-\\Delta G_I)}{1+\\exp(-\\Delta G_C)+ \\exp(-\\Delta G_R)+ \\exp(-\\Delta G_C- \\Delta G_R- \\Delta G_I)} \n",
     "$$ \n",
+    "\n",
     "in which $t_{sat}$ is the transcription rate resulting from full RNAP occupancy. \n",
     "\n",
     "Here, the $\\Delta G_C$ and $\\Delta G_R$ are trainable matrices (weights of the neural network) and $\\Delta G_I$ and $t_{sat}$ are trainable scalars.\n",


### PR DESCRIPTION
Not sure if this will fix the issue, but the "in which" line is being read in as an equation, as seen on:
https://mavenn.readthedocs.io/en/latest/tutorials/5_promoter_biophysical_gpmaps.html?highlight=%22is%20summarized%20below%22